### PR TITLE
[BottomTab] bottomTab 아이콘 색상 변경 및 코드 구조 변경

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,70 +1,79 @@
-import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View } from 'react-native';
-import { NavigationContainer } from '@react-navigation/native';
-import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-import { useEffect, useState } from 'react';
-import { Ionicons } from '@expo/vector-icons';
+import { StatusBar } from "expo-status-bar";
+import { StyleSheet, Text, View } from "react-native";
+import { NavigationContainer } from "@react-navigation/native";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
+import { useEffect, useState } from "react";
+import { Ionicons } from "@expo/vector-icons";
 
-import SplashScreen from './screens/SplashScreen';
-import SignInScreen from './screens/SignInScreen';
-import HomeScreen from './screens/HomeScreen';
-import VocaSearchScreen from './screens/VocaSearchScreen';
-import VocaListScreen from './screens/VocaListScreen';
-import MyPageScreen from './screens/MyPageScreen';
-import TodaySalaryScreen from './screens/TodaySalaryScreen';
-import TodayTrendQuizScreen from './screens/TodayTrendQuizScreen';
+import SplashScreen from "./screens/SplashScreen";
+import SignInScreen from "./screens/SignInScreen";
+import HomeScreen from "./screens/HomeScreen";
+import VocaSearchScreen from "./screens/VocaSearchScreen";
+import VocaListScreen from "./screens/VocaListScreen";
+import MyPageScreen from "./screens/MyPageScreen";
+import TodaySalaryScreen from "./screens/TodaySalaryScreen";
+import TodayTrendQuizScreen from "./screens/TodayTrendQuizScreen";
 
 const Stack = createNativeStackNavigator();
 const BottomTab = createBottomTabNavigator();
 
+const tabScreensProps = [
+  {
+    screenName: "Home",
+    title: "홈",
+    iconTitle: "home",
+    screen: HomeScreen,
+  },
+  {
+    screenName: "VocabularySearch",
+    title: "단어 검색",
+    iconTitle: "search",
+    screen: VocaSearchScreen,
+  },
+  {
+    screenName: "VocabularyList",
+    title: "단어장",
+    iconTitle: "bookmark",
+    screen: VocaListScreen,
+  },
+  {
+    screenName: "MyPage",
+    title: "마이페이지",
+    iconTitle: "person",
+    screen: MyPageScreen,
+  },
+];
+
 function BottomTabNavigator() {
   return (
     <BottomTab.Navigator>
-      <BottomTab.Screen
-        name="Home"
-        component={HomeScreen}
-        options={{
-          title: '홈',
-          headerShown: false,
-          tabBarIcon: ({ color, size }) => (
-            <Ionicons name="home" color={color} size={size} />
-          ),
-        }}
-      />
-      <BottomTab.Screen
-        name="VocabularySearch"
-        component={VocaSearchScreen}
-        options={{
-          title: '단어 검색',
-          headerShown: false,
-          tabBarIcon: ({ color, size }) => (
-            <Ionicons name="search" color={color} size={size} />
-          ),
-        }}
-      />
-      <BottomTab.Screen
-        name="VocabularyList"
-        component={VocaListScreen}
-        options={{
-          title: '단어장',
-          headerShown: false,
-          tabBarIcon: ({ color, size }) => (
-            <Ionicons name="bookmark" color={color} size={size} />
-          ),
-        }}
-      />
-      <BottomTab.Screen
-        name="MyPage"
-        component={MyPageScreen}
-        options={{
-          title: '마이페이지',
-          headerShown: false,
-          tabBarIcon: ({ color, size }) => (
-            <Ionicons name="person" color={color} size={size} />
-          ),
-        }}
-      />
+      {tabScreensProps.map((item) => (
+        <BottomTab.Screen
+          key={item.screenName}
+          name={item.screenName}
+          component={item.screen}
+          options={{
+            title: item.title,
+            headerShown: false,
+            tabBarLabelStyle: {
+              fontSize: 12,
+              fontWeight: "400",
+            },
+            tabBarIcon: ({ focused, color, size }) =>
+              focused ? (
+                <Ionicons name={item.iconTitle} color={color} size={size} />
+              ) : (
+                <Ionicons
+                  name={`${item.iconTitle}-outline`}
+                  color={color}
+                  size={size}
+                ></Ionicons>
+              ),
+            tabBarActiveTintColor: "#313131",
+          }}
+        />
+      ))}
     </BottomTab.Navigator>
   );
 }
@@ -75,7 +84,7 @@ export default function App() {
 
   function handleLogIn() {
     setIsLoggedIn(true);
-    console.log('버튼은 눌리고 있어요');
+    console.log("버튼은 눌리고 있어요");
   }
 
   useEffect(() => {
@@ -135,8 +144,8 @@ export default function App() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
+    backgroundColor: "#fff",
+    alignItems: "center",
+    justifyContent: "center",
   },
 });


### PR DESCRIPTION
## 📌 수행한 작업의 종류
  - [x] 퍼블리싱

## 📌 작업 수행 내용 / 수정사항
- **바텀네비바를 수정**
   1) focused 상태일 경우의 activeColor 변경
   2) tabBarLabel의 스타일을 추가
   3) tab이 눌렸을 때 filled 속성을 추가한 아이콘이 렌더링되도록 함

- **BottomTabNavigator 코드 수정**
    option을 추가하다보니 코드가 너무 길어져 각 tab마다의 속성을 담은 배열을 정의하여 map 함수를 사용하도록 대체했습니다. 

## 📌 트러블 슈팅: 어려웠던 점을 공유해주세요!
처음에는 map 함수에서 리턴하는 또다른 컴포넌트를 정의했으나, Navigator에서는 direct children으로 'Screen', 'Group' or 'React.Fragment' 만을 가질 수 있다고 하여 따로 정의해둔 컴포넌트를 map 함수 내부에서 리턴하도록 수정했습니다.

## 📌 스크린샷/ GIF (UI/UX 관련 작업)
![simulator_screenshot_D2EAA5EB-5CEB-4055-BAE6-D6DC809F7EBB](https://github.com/user-attachments/assets/6eb480be-09eb-4bb9-ae0d-268d313b9af0)


## 📌 구현을 위해 참고한 링크 혹은 라이브러리
- 